### PR TITLE
🧹 [code health improvement] Remove unused AccelerateInterpolator import

### DIFF
--- a/launcher/app/src/main/java/com/skarm/launcher/GameActivity.kt
+++ b/launcher/app/src/main/java/com/skarm/launcher/GameActivity.kt
@@ -19,7 +19,6 @@ import android.view.MotionEvent
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.View
-import android.view.animation.AccelerateInterpolator
 import android.view.WindowManager
 import android.widget.EditText
 import android.widget.Toast


### PR DESCRIPTION
🎯 **What:** Removed the unused `AccelerateInterpolator` import from `GameActivity.kt`.
💡 **Why:** Unused imports clutter the codebase and make it slightly harder to read and maintain. Removing them improves code cleanliness without affecting any functionality.
✅ **Verification:** Verified the fix by successfully running `./gradlew test` to ensure there are no compilation errors or broken tests.
✨ **Result:** A cleaner `GameActivity.kt` file.

---
*PR created automatically by Jules for task [12943458474632913112](https://jules.google.com/task/12943458474632913112) started by @SirDank*