### PR TITLE
⚡ [Performance] Avoid object allocation in TouchButtonView.onDraw

### DIFF
--- a/launcher/app/src/main/java/com/skarm/launcher/touch/TouchControlViews.kt
+++ b/launcher/app/src/main/java/com/skarm/launcher/touch/TouchControlViews.kt
@@ -222,12 +222,14 @@ class TouchButtonView(context: Context, node: ControlNode) : BaseTouchControl(co
     private var isPressedState = false
     private var isToggledOn = false
 
+    private val buttonRect = RectF()
+
     override fun onDraw(canvas: Canvas) {
         val centerX = width / 2f
         val centerY = height / 2f
         val size = min(width, height).toFloat()
         
-        val rect = RectF(
+        buttonRect.set(
             centerX - size / 2f,
             centerY - size / 2f,
             centerX + size / 2f,
@@ -238,7 +240,7 @@ class TouchButtonView(context: Context, node: ControlNode) : BaseTouchControl(co
         
         // Use a rounded square instead of a circle
         val cornerRadius = size * 0.25f
-        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, bgPaint)
+        canvas.drawRoundRect(buttonRect, cornerRadius, cornerRadius, bgPaint)
         
         // Draw label
         if (node.label.isNotEmpty()) {


### PR DESCRIPTION
💡 **What:** Moved `RectF` allocation in `TouchButtonView.onDraw` to a class member and updated it with `.set()` instead of creating a new object every frame.
🎯 **Why:** Object allocations in `onDraw` are a well-known Android performance anti-pattern. Since `onDraw` can be called 60 times a second during animations, allocating objects inside it triggers garbage collection more frequently, leading to frame drops. Moving the allocation to initialization and mutating the object directly resolves this overhead.
📊 **Measured Improvement:** I was unable to show a meaningful performance improvement because the Gradle build fails from missing heavy assets (lwjgl) that cannot be easily built in the sandbox environment, making it impractical to run a full device-based or Robolectric-based benchmark test. However, this is a standard and universally accepted performance optimization for Android Views.

---
*PR created automatically by Jules for task [12663536340180543958](https://jules.google.com/task/12663536340180543958) started by @SirDank*