### PR TITLE
⚡ perf: cache SharedPreferences instance in LauncherActivity

### DIFF
--- a/launcher/app/src/main/java/com/skarm/launcher/LauncherActivity.kt
+++ b/launcher/app/src/main/java/com/skarm/launcher/LauncherActivity.kt
@@ -100,6 +100,8 @@ class LauncherActivity : AppCompatActivity() {
             insets
         }
 
+        val launcherPrefs = getSharedPreferences("launcher_prefs", MODE_PRIVATE)
+
         // Segmented control listener
         binding.modeToggleGroup.addOnButtonCheckedListener { group, checkedId, isChecked ->
             val button = group.findViewById<MaterialButton>(checkedId) ?: return@addOnButtonCheckedListener
@@ -109,7 +111,7 @@ class LauncherActivity : AppCompatActivity() {
                 button.setBackgroundColor(android.graphics.Color.parseColor("#ab4a81"))
                 button.setTextColor(android.graphics.Color.WHITE)
                 val mode = if (checkedId == R.id.btn_mode_steam) "Steam" else "Web"
-                getSharedPreferences("launcher_prefs", MODE_PRIVATE).edit().putString("login_mode", mode).apply()
+                launcherPrefs.edit().putString("login_mode", mode).apply()
             } else {
                 button.textSize = 13f
                 button.setTypeface(null, android.graphics.Typeface.NORMAL)
@@ -119,7 +121,7 @@ class LauncherActivity : AppCompatActivity() {
         }
 
         // Restore saved selection
-        val savedMode = getSharedPreferences("launcher_prefs", MODE_PRIVATE).getString("login_mode", "Web")
+        val savedMode = launcherPrefs.getString("login_mode", "Web")
         if (savedMode == "Steam") {
             binding.modeToggleGroup.check(R.id.btn_mode_steam)
             binding.btnModeSteam.textSize = 15f
@@ -166,7 +168,6 @@ class LauncherActivity : AppCompatActivity() {
 
         // Avoid screen edges switch
         val avoidEdgesSwitch = binding.switchAvoidEdges
-        val launcherPrefs = getSharedPreferences("launcher_prefs", MODE_PRIVATE)
         avoidEdgesSwitch.isChecked = launcherPrefs.getBoolean("avoid_screen_edges", false)
         avoidEdgesSwitch.setOnCheckedChangeListener { _, isChecked ->
             launcherPrefs.edit().putBoolean("avoid_screen_edges", isChecked).apply()

--- a/rationale.txt
+++ b/rationale.txt
@@ -1,0 +1,3 @@
+Rationale for Performance Improvement:
+Calling `getSharedPreferences` multiple times requires the Android context to look up the preference file name, check its internal cache (a synchronized map), and return the SharedPreferences instance. While Android caches this instance, looking it up multiple times still incurs map lookups, string hash code calculations, and synchronization overhead.
+By caching the `SharedPreferences` instance in a local variable `launcherPrefs` at the start of `onCreate`, we bypass this redundant work, improving the initialization speed of `LauncherActivity` and the execution speed of the UI listeners (like `addOnButtonCheckedListener`).

--- a/rationale.txt
+++ b/rationale.txt
@@ -1,3 +1,0 @@
-Rationale for Performance Improvement:
-Calling `getSharedPreferences` multiple times requires the Android context to look up the preference file name, check its internal cache (a synchronized map), and return the SharedPreferences instance. While Android caches this instance, looking it up multiple times still incurs map lookups, string hash code calculations, and synchronization overhead.
-By caching the `SharedPreferences` instance in a local variable `launcherPrefs` at the start of `onCreate`, we bypass this redundant work, improving the initialization speed of `LauncherActivity` and the execution speed of the UI listeners (like `addOnButtonCheckedListener`).


### PR DESCRIPTION
💡 **What:** Extracted multiple calls to `getSharedPreferences("launcher_prefs", MODE_PRIVATE)` into a single local variable `launcherPrefs` at the start of `LauncherActivity.onCreate()`.

🎯 **Why:** To optimize initialization speed and listener execution. Calling `getSharedPreferences` multiple times repeatedly causes Android to look up the preference file and its synchronized cache map, which introduces unnecessary overhead.

📊 **Measured Improvement:** The initialization time improvement is micro-optimization level and very difficult to reliably measure without introducing excessive noise on standard Android device benchmarks, therefore no explicit benchmark numbers are provided. However, avoiding repeated synchronized map/context lookup operations inside `onCreate` is a proven best practice for reducing startup overhead in Android.

---
*PR created automatically by Jules for task [3583629432423435584](https://jules.google.com/task/3583629432423435584) started by @SirDank*