### PR TITLE
🧹 Suboptimal Exception Logging in TouchControlModels

### DIFF
--- a/launcher/app/src/main/java/com/skarm/launcher/touch/TouchControlModels.kt
+++ b/launcher/app/src/main/java/com/skarm/launcher/touch/TouchControlModels.kt
@@ -1,6 +1,7 @@
 package com.skarm.launcher.touch
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.Keep
 import com.google.gson.Gson
 
@@ -43,6 +44,7 @@ data class TouchLayoutData(
 )
 
 object TouchControlManager {
+    private const val TAG = "TouchControlManager"
     private const val PREFS_NAME = "touch_controls_prefs"
     private const val KEY_LAYOUT_DATA = "layout_data"
 
@@ -93,7 +95,7 @@ object TouchControlManager {
             data.renderScale = data.renderScale.coerceIn(MIN_RENDER_SCALE, MAX_RENDER_SCALE)
             data
         } catch (e: Exception) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to parse touch layout data", e)
             createDefaultLayout()
         }
     }


### PR DESCRIPTION
🎯 **What:** 
Replaced `e.printStackTrace()` with `Log.e(TAG, "Failed to parse touch layout data", e)` in `TouchControlManager.loadLayout()`. Added the necessary `import android.util.Log` and defined `TAG` inside the `TouchControlManager` object.

💡 **Why:** 
Calling `e.printStackTrace()` is considered a suboptimal practice in Android development because it writes to standard error stream (`System.err`), which can be harder to filter and monitor in Logcat compared to using the standard Android `Log` utility with proper severity levels and tags. This change improves log discoverability and codebase maintainability.

✅ **Verification:** 
I verified the change by manually checking the modified file using `cat` and running automated code review, which passed cleanly. Building tests revealed an expected dependency initialization problem unrelated to this logic, but the actual change consists solely of replacing one logging method with another equivalent, safe one that properly retains exception context.

✨ **Result:** 
Exceptions during touch layout parsing are now appropriately categorized in standard Android logs, improving runtime telemetry and debugging.

---
*PR created automatically by Jules for task [8218953139566950744](https://jules.google.com/task/8218953139566950744) started by @SirDank*