### PR TITLE
🧹 Code Health: Add log to empty catch block in GameActivity socket server

### DIFF
--- a/launcher/app/src/main/java/com/skarm/launcher/GameActivity.kt
+++ b/launcher/app/src/main/java/com/skarm/launcher/GameActivity.kt
@@ -542,6 +542,7 @@ class GameActivity :
                 val client = try {
                     server.accept()
                 } catch (e: IOException) {
+                    Log.w(TAG, "url server closed or accept failed", e)
                     break
                 }
                 try {


### PR DESCRIPTION
🎯 **What:** The empty `catch` block that was swallowing `IOException` on `server.accept()` in `GameActivity` has been updated to log the exception before breaking out of the loop.

💡 **Why:** This improves maintainability and observability by logging the error, making it easier to troubleshoot if the url socket server unexpectedly fails to accept connections or closes.

✅ **Verification:**
- Ran the full `./gradlew app:lint app:testDebugUnitTest` suite to ensure no regressions were introduced.
- Verified the code health issue is resolved without changing existing functional behavior.

✨ **Result:** Improved observability and code health without introducing behavioral changes.

---
*PR created automatically by Jules for task [2469306352755592337](https://jules.google.com/task/2469306352755592337) started by @SirDank*